### PR TITLE
pmt_pid is based by channel index  and mptsd can remux when pmt table changed

### DIFF
--- a/config.c
+++ b/config.c
@@ -142,7 +142,7 @@ int config_load_channels(CONFIG *conf) {
 				}
 				// Init channel
 				if (channel == NULL) {
-					channel = channel_new(service_id, is_radio, id, name, source);
+					channel = channel_new(service_id, is_radio, id, name, source, i);
 				} else {
 					chansrc_add(channel, source);
 				}
@@ -222,7 +222,7 @@ int config_load_channels(CONFIG *conf) {
 		if (r->cookie != cookie) {
 			proxy_log(r, "Remove");
 			/* Replace channel reference with real object and instruct free_restreamer to free it */
-			r->channel = channel_new(r->channel->service_id, r->channel->radio, r->channel->id, r->channel->name, r->channel->source);
+			r->channel = channel_new(r->channel->service_id, r->channel->radio, r->channel->id, r->channel->name, r->channel->source, r->channel->index);
 			r->freechannel = 1;
 			r->dienow = 1;
 		}

--- a/data.c
+++ b/data.c
@@ -134,7 +134,7 @@ CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *n
 	CHANNEL *c = calloc(1, sizeof(CHANNEL));
 	c->service_id = service_id;
 	c->radio = is_radio;
-    c->index = channel_index;
+	c->index = channel_index;
 	c->base_pid = c->index * 32; // The first pid is saved for PMT , channel_index must > 0
 	c->pmt_pid = c->base_pid; // The first pid is saved for PMT
 	c->id = strdup(id);

--- a/data.c
+++ b/data.c
@@ -88,7 +88,7 @@ void chansrc_free(CHANSRC **purl) {
 	}
 };
 
-void chansrc_add(CHANNEL *c, char *src) {
+void chansrc_add(CHANNEL *c, const char *src) {
 	if (c->num_src >= MAX_CHANNEL_SOURCES-1)
 		return;
 	c->sources[c->num_src] = strdup(src);
@@ -121,15 +121,27 @@ void chansrc_set(CHANNEL *c, uint8_t src_id) {
 
 
 
-CHANNEL *channel_new(int service_id, int is_radio, char *id, char *name, char *source) {
+CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, const char *source, int channel_index){
+
+    if (channel_index<=0 || channel_index>=256)
+    {
+        
+	    LOGf("CONFIG: Error channel_new invalid index %d\n", channel_index);
+        return NULL;
+    }
+    //LOGf("CONFIG: ------------------channel_new() serviceid %d id %s name %s source %s index %d\n", service_id, id, name , source , channel_index);
+    
 	CHANNEL *c = calloc(1, sizeof(CHANNEL));
 	c->service_id = service_id;
 	c->radio = is_radio;
-	c->base_pid = service_id * 32; // The first pid is saved for PMT
+    c->index = channel_index;
+	c->base_pid = c->index * 32; // The first pid is saved for PMT , channel_index must > 0
 	c->pmt_pid = c->base_pid; // The first pid is saved for PMT
 	c->id = strdup(id);
 	c->name = strdup(name);
 	chansrc_add(c, source);
+
+
 	return c;
 }
 

--- a/data.h
+++ b/data.h
@@ -59,6 +59,7 @@ typedef struct {
 
 typedef struct {
 	/* Config */
+    int         index;
 	int			base_pid;
 	int			service_id;
 	int			pmt_pid;
@@ -219,7 +220,7 @@ EPG_ENTRY *	epg_new			(time_t start, int duration, char *encoding, char *event, 
 void		epg_free		(EPG_ENTRY **e);
 int			epg_changed		(EPG_ENTRY *a, EPG_ENTRY *b);
 
-CHANNEL *	channel_new		(int service_id, int is_radio, char *id, char *name, char *source);
+CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, const char *source, int channel_index);
 void		channel_free	(CHANNEL **c);
 void		channel_free_epg(CHANNEL *c);
 
@@ -228,7 +229,7 @@ int is_rtp(char *url);
 
 CHANSRC *	chansrc_init	(char *url);
 void		chansrc_free	(CHANSRC **url);
-void		chansrc_add		(CHANNEL *c, char *src);
+void		chansrc_add		(CHANNEL *c, const char *src);
 void		chansrc_next	(CHANNEL *c);
 void		chansrc_set		(CHANNEL *c, uint8_t src_id);
 

--- a/data.h
+++ b/data.h
@@ -59,7 +59,7 @@ typedef struct {
 
 typedef struct {
 	/* Config */
-    int         index;
+	int			index;
 	int			base_pid;
 	int			service_id;
 	int			pmt_pid;

--- a/input.c
+++ b/input.c
@@ -185,7 +185,7 @@ int process_pat(INPUT *r, uint16_t pid, uint8_t *ts_packet) {
 	
 	if (s->last_pat->initialized) {
 		if (!ts_pat_is_same(s->pat, s->last_pat)) {
-			proxy_log(r, "PAT changed.");
+			proxy_log(r, "========================PAT changed.========================");
 			return -1; // Reconnect
 		}
 		ts_pat_free(&s->last_pat);
@@ -243,15 +243,17 @@ int process_pmt(INPUT *r, uint16_t pid, uint8_t *ts_packet) {
 
 	s->pmt = ts_pmt_push_packet(s->pmt, ts_packet);
 
-	s->last_pmt = ts_pmt_push_packet(s->last_pmt, ts_packet);
+	
 	if (s->last_pmt->initialized) {
 		if (!ts_pmt_is_same(s->pmt, s->last_pmt)) {
-			proxy_log(r, "PMT changed.");
+			proxy_log(r, "========================PMT changed.========================");
 			return -2; // Reconnect
 		}
 		ts_pmt_free(&s->last_pmt);
 		s->last_pmt = ts_pmt_alloc();
 	}
+
+    s->last_pmt = ts_pmt_push_packet(s->last_pmt, ts_packet);
 
 	if (s->pmt->initialized) {
 		if (!s->pmt_rewritten || !s->pmt_rewritten->initialized) {

--- a/input.c
+++ b/input.c
@@ -191,7 +191,7 @@ int process_pat(INPUT *r, uint16_t pid, uint8_t *ts_packet) {
 		ts_pat_free(&s->last_pat);
 		s->last_pat = ts_pat_alloc();
 	}
-    s->last_pat = ts_pat_push_packet(s->last_pat, ts_packet);
+	s->last_pat = ts_pat_push_packet(s->last_pat, ts_packet);
 	if (s->pat->initialized) {
 		// PMT pid is still unknown
 		if (!s->pmt_pid) {
@@ -253,7 +253,7 @@ int process_pmt(INPUT *r, uint16_t pid, uint8_t *ts_packet) {
 		s->last_pmt = ts_pmt_alloc();
 	}
 
-    s->last_pmt = ts_pmt_push_packet(s->last_pmt, ts_packet);
+	s->last_pmt = ts_pmt_push_packet(s->last_pmt, ts_packet);
 
 	if (s->pmt->initialized) {
 		if (!s->pmt_rewritten || !s->pmt_rewritten->initialized) {


### PR DESCRIPTION
1. 	mptsd can remux when pmt table changed
2.     pmt_pid is based by channel index ( >0 && <256 ), pmt_id = channel_index*32 .  
         originally the output ts stream 's pmt_pid is based by service_id , and pmt_id = service_id*32 , it may be overflow or duplicated. ( somebody config service_id as 1000,1001,1002 ...)
3.      don't expand tab(to 4 spaces) in source code 