### PR TITLE
Make Makefile more friendly to packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-CC = $(CROSS)$(TARGET)gcc
+CC? = $(CROSS)$(TARGET)gcc
 STRIP = $(CROSS)$(TARGET)strip
 BUILD_ID = $(shell date +%F_%R)
 VERSION="v1.1"
 GIT_VER = $(shell git describe --tags --dirty --always 2>/dev/null)
-CFLAGS = -ggdb -Wall -Wextra -Wshadow -Wformat-security -Wno-strict-aliasing -O2 -D_GNU_SOURCE -DBUILD_ID=\"$(BUILD_ID)\"
+CFLAGS ?= -ggdb -O2
+CFLAGS += -Wall -Wextra -Wshadow -Wformat-security -Wno-strict-aliasing -D_GNU_SOURCE -DBUILD_ID=\"$(BUILD_ID)\"
 ifneq "$(GIT_VER)" ""
 CFLAGS += -DGIT_VER=\"$(GIT_VER)\"
 else


### PR DESCRIPTION
CC and CFLAGS may be provided by the system, so the Makefile should not override them, only append local project-specific CFLAGS.