### PR TITLE
Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 CC = $(CROSS)$(TARGET)gcc
 STRIP = $(CROSS)$(TARGET)strip
-BUILD_ID = $(shell date +%F_%R)
 VERSION="v1.1"
+ifndef REPRODUCIBLE_BUILD
+BUILD_ID = $(shell date +%F_%R)
 GIT_VER = $(shell git describe --tags --dirty --always 2>/dev/null)
+endif
 CFLAGS = -ggdb -Wall -Wextra -Wshadow -Wformat-security -Wno-strict-aliasing -O2 -D_GNU_SOURCE -DBUILD_ID=\"$(BUILD_ID)\"
 ifneq "$(GIT_VER)" ""
 CFLAGS += -DGIT_VER=\"$(GIT_VER)\"

--- a/mptsd.c
+++ b/mptsd.c
@@ -34,7 +34,11 @@
 
 #define PROGRAM_NAME "ux-mptsd"
 
+#ifdef BUILD_ID
 const char *program_id = PROGRAM_NAME " " GIT_VER " build " BUILD_ID;
+#else
+const char *program_id = PROGRAM_NAME " " GIT_VER;
+#endif
 
 char *server_sig = PROGRAM_NAME;
 char *server_ver = GIT_VER;


### PR DESCRIPTION
Improve compatibility with [reproducible builds](https://reproducible-builds.org/).

I suggest to make it unconditional. There are two problems here: using `date` hinders build reproducibility, and using `git` creates unneeded build-time dependency on git, and makes build behavior inconsistent depending on whether git is available.