### PR TITLE
Allows specification of the output file

### DIFF
--- a/config.c
+++ b/config.c
@@ -89,6 +89,7 @@ void config_free(CONFIG **pconf) {
 		FREE(conf->epg_conf);
 		FREE(conf->network_name);
 		FREE(conf->provider_name);
+		FREE(conf->output_filename);
 		FREE(*pconf);
 	}
 }
@@ -441,6 +442,7 @@ static void show_usage(void) {
 	puts("\t-D\t\tDebug");
 	puts("");
 	puts("\t-W\t\tWrite output file");
+	puts("\t-f\t\tThe output filename           (default: mptsd-output.ts)");
 	puts("\t-E\t\tWrite input file");
 	puts("");
 }
@@ -455,7 +457,7 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	conf->server_port = 0;
 	conf->server_socket = -1;
 
-	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:qDHhWE")) != -1) {
+	while ((j = getopt(argc, argv, "i:b:p:g:c:n:e:d:t:o:O:P:l:L:B:m:f:qDHhWE")) != -1) {
 		switch (j) {
 			case 'i':
 				conf->ident = strdup(optarg);
@@ -532,7 +534,9 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 				break;
 			case 'W':
 				conf->write_output_file = 1;
-				output_open_file(conf->output);
+				break;
+			case 'f':
+				conf->output_filename = strdup(optarg);
 				break;
 			case 'E':
 				conf->write_input_file = 1;
@@ -572,12 +576,20 @@ void config_load(CONFIG *conf, int argc, char **argv) {
 	if (!conf->epg_conf) {
 		conf->epg_conf = strdup("mptsd_epg.conf");
 	}
+	if (!conf->output_filename) {
+		conf->output_filename = strdup("mptsd-output.ts");
+	}
 
 	// Align bitrate to 1 packet (1316 bytes)
 	conf->output_bitrate        *= 1000000; // In bytes
 	conf->output_packets_per_sec = ceil(conf->output_bitrate / (1316 * 8));
 	conf->output_bitrate         = conf->output_packets_per_sec * (1316 * 8);
 	conf->output_tmout           = 1000000 / conf->output_packets_per_sec;
+
+	// Open the filename if we want to write to a file
+	if(conf->write_output_file) {
+		output_open_file(conf->output_filename, conf->output);
+	}
 
 	if (conf->server_port)
 		init_server_socket(conf->server_addr, conf->server_port, &conf->server, &conf->server_socket);

--- a/config.h
+++ b/config.h
@@ -53,7 +53,9 @@ typedef struct {
 	int				quiet;
 
 	int				write_input_file;
-	int				write_output_file;
+	int				write_output_file;  // 0 - do not write an output file
+										// 1 - write output files
+	char			*output_filename;   // filename to write to
 	int				pcr_mode;			// 0 - do not touch PCRs
 										// 1 - move PCRs to their calculated place
 										// 2 - rewrite PCRs using output bitrate

--- a/data.c
+++ b/data.c
@@ -298,8 +298,13 @@ OUTPUT *output_new() {
 	return o;
 }
 
-void output_open_file(OUTPUT *o) {
-	o->ofd = open("mptsd-output.ts", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+void output_open_file(char *filename, OUTPUT *o) {
+	int fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
+	if (fd == -1) {
+		perror("Cannot open output file\n");
+		exit(1);
+	}
+	o->ofd = fd;
 }
 
 void obuf_reset(OBUF *ob) {

--- a/data.h
+++ b/data.h
@@ -240,7 +240,7 @@ void		input_stream_reset	(INPUT *input);
 
 OUTPUT *	output_new			();
 void		output_free			(OUTPUT **output);
-void		output_open_file	(OUTPUT *o);
+void		output_open_file	(char *filename, OUTPUT *o);
 void		output_buffer_alloc	(OUTPUT *o, double output_bitrate);
 void		obuf_reset			(OBUF *ob);
 


### PR DESCRIPTION
Adds a new option (`-f`) to store the filename, if none is specified use the current default filename (`mptsd-output.ts`).