### PR TITLE
Perfect PCR compatibility

### DIFF
--- a/README
+++ b/README
@@ -33,11 +33,12 @@ you can change to suit your needs.
 
 One mptsd instance should be used for each transponder.
 
-Limitations
-===========
-mptsd do not apply PCR restamping to output. If hardware modulator requires
-correct PCR (most cheap modulators do) it probably won't like what mptsd
-outputs. mptsd was tested and found to be working ok with Dektec DTE-3114.
+Output Stream
+=============
+mptsd can achieve perfect PCR restamping to output using "-m 3".
+This is useful for hardware modulators that require correct PCR values
+(most cheap modulators do, so always use "-m 3" with them).
+mptsd was tested and found to be working ok with Dektec DTE-3114 & HiDes UT-100C.
 
 Development
 ===========

--- a/data.c
+++ b/data.c
@@ -256,7 +256,7 @@ INPUT * input_new(const char *name, CHANNEL *channel) {
 		FREE(tmp);
 	}
 
-	r->buf = cbuf_init(1428 * 1316, channel->id); // ~ 10000 x 188
+	r->buf = cbuf_init(1428 * 1316 * 4, channel->id); // ~ 40000 x 188
 
 	input_stream_alloc(r);
 


### PR DESCRIPTION
Instead of forward the distance from the current PCR and the last PCR over next packets to read, this patch backguards it to the previous packets. So it calculates the needed packets between new PCR packet and the last, and only continues reading packets from this source until the distance is covered. In fact, it slowdowns the reading speed from the input buffer using the PCR marks.

So, now you can use the parameter `-m 1` (or `-m 3`) and achieve the expected behaviour.

This PR supersedes #23, and fixes #18.