### PR TITLE
Go to next input when in the root of the list

### DIFF
--- a/output_mix.c
+++ b/output_mix.c
@@ -137,6 +137,10 @@ void * output_handle_mix(void *_config) {
 			while (inputs_left--) {
 				inpt = inpt->next;
 				INPUT *r = inpt->data;
+				if (!r) { // Skip the empty root!
+					inpt = inpt->next;
+					r = inpt->data;
+				}
 				if (!r || !r->buf)
 					continue;
 


### PR DESCRIPTION
When rotating over the list of inputs, you traverse the root of the list. This is an empty node, so you need to advance to the next element.

So, without this code a *SEVERE* bug exists inside the muxing task: Every time you go over the root of the list, then a NULL padding packet is inserted in the output. This consumes around 1/N of the bandwith (where N is the number of inputs). This patch fixes the bug and no padding is inserted when data is in the input buffer.