### PR TITLE
Set a correct Adaptation Field Control value for pid 1FFF

### DIFF
--- a/output_write.c
+++ b/output_write.c
@@ -55,8 +55,10 @@ void ts_frame_process(CONFIG *conf, OUTPUT *o, uint8_t *data) {
 		ts_packet = data + i;
 		pid = ts_packet_get_pid(ts_packet);
 
-		if (pid == 0x1fff) // NULL packet
+		if (pid == 0x1fff) { // NULL packet
+			ts_packet[3] = 0x10; // set no adaptation field, payload only
 			o->padding_period += TS_PACKET_SIZE;
+		}
 
 		if (ts_packet_has_pcr(ts_packet)) {
 			uint64_t pcr = ts_packet_get_pcr(ts_packet);	// Current PCR


### PR DESCRIPTION
The header of the null padding packets (pid 1FFF) is invalid, because it's using the RESERVED 0x00 value for the Adaptation Field Control. This patch solves the problem setting the 0x01 value (no adaptation field, payload only). Some scanners that check the consistency of the TS warn about this.