### PR TITLE
Enable stdout for file output

### DIFF
--- a/config.c
+++ b/config.c
@@ -448,7 +448,7 @@ static void show_usage(void) {
 	puts("\t-D\t\tDebug");
 	puts("");
 	puts("\t-W\t\tWrite output file           (recommended to use with -N)");
-	puts("\t-f\t\tThe output filename         (default: mptsd-output.ts)");
+	puts("\t-f\t\tThe output filename         (default: mptsd-output.ts) (use - for stdout)");
 	puts("\t-E\t\tWrite input file");
 	puts("");
 }

--- a/data.c
+++ b/data.c
@@ -303,7 +303,12 @@ OUTPUT *output_new() {
 }
 
 void output_open_file(char *filename, OUTPUT *o) {
-	int fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
+	int fd = -1;
+	if (strcmp(filename, "-") == 0) {
+		fd = STDOUT_FILENO;
+	} else {
+		fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
+	}
 	if (fd == -1) {
 		perror("Cannot open output file\n");
 		exit(1);


### PR DESCRIPTION
Added the option of using "-" as the filename of the file output. This enables the use the tool in a PIPE to feed other tools (mainly a modulator).
