### PR TITLE
Add LCN support

### DIFF
--- a/config.h
+++ b/config.h
@@ -61,6 +61,7 @@ typedef struct {
 										// 1 - move PCRs to their calculated place
 										// 2 - rewrite PCRs using output bitrate
 										// 3 - move PCRs and rewrite them
+	int				use_lcn;
 
 	uint16_t		network_id;			// For NIT && SDT
 	uint16_t		transport_stream_id;// For NIT

--- a/data.c
+++ b/data.c
@@ -121,7 +121,7 @@ void chansrc_set(CHANNEL *c, uint8_t src_id) {
 
 
 
-CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index){
+CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible){
 
     if (channel_index<=0 || channel_index>=256)
     {
@@ -135,6 +135,8 @@ CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *n
 	c->service_id = service_id;
 	c->radio = is_radio;
 	c->index = channel_index;
+	c->lcn = lcn;
+	c->lcn_visible = is_lcn_visible;
 	c->base_pid = c->index * 32; // The first pid is saved for PMT , channel_index must > 0
 	c->pmt_pid = c->base_pid; // The first pid is saved for PMT
 	c->id = strdup(id);

--- a/data.h
+++ b/data.h
@@ -64,6 +64,8 @@ typedef struct {
 	int			service_id;
 	int			pmt_pid;
 	int			radio;
+	int			lcn;
+	int			lcn_visible;
 	char *		id;
 	char *		name;
 	int			eit_mode; /* 0 = ignore EIT data from input
@@ -229,7 +231,7 @@ EPG_ENTRY *	epg_new			(time_t start, int duration, char *encoding, char *event, 
 void		epg_free		(EPG_ENTRY **e);
 int			epg_changed		(EPG_ENTRY *a, EPG_ENTRY *b);
 
-CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index);
+CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible);
 void		channel_free	(CHANNEL **c);
 void		channel_free_epg(CHANNEL *c);
 

--- a/mptsd_channels.conf
+++ b/mptsd_channels.conf
@@ -6,50 +6,64 @@ transport_stream_id = 1
 service_id	= 1
 id			= btv
 name		= bTV
-eit_mode    = 0 # 0 = ignore EIT data from input
+eit_mode	= 0 # 0 = ignore EIT data from input
 				# 1 = forward EIT data for the configured service, ignore any other EIT data
 source1		= http://signal-server/stb/btv.mpg
 #source2		= http://signal-server2/stb/btv.mpg
 #source3		= http://signal-server3/stb/btv.mpg
 #source4		= udp://239.0.0.1:5000/
-#source5        = rtp://239.78.78.2:5000/
+#source5		= rtp://239.78.78.2:5000/
 #worktime	= 14:18-14:19
+lcn			= 2
+lcn_visible	= yes
 
 [Channel2]
 service_id	= 2
 id			= kanal1
 name		= "Kanal 1"
 source		= http://signal-server/stb/kanal1.mpg
+lcn			= 2
+lcn_visible	= yes
 
 [Channel3]
 service_id	= 3
 id			= novatv
 name		= "Nova"
 source1		= http://signal-server/stb/novatv.mpg
+lcn			= 3
+lcn_visible	= yes
 
 [Channel4]
 service_id	= 4
 id			= tv2
 name		= "TV 2"
 source1		= http://signal-server/stb/tv2.mpg
+lcn			= 7
+lcn_visible	= yes
 
 [Channel5]
 service_id	= 5
 id			= ngc
 name		= "NatGeo"
 source1		= http://signal-server/stb/ngc.mpg
+lcn			= 72
+lcn_visible	= yes
 
 [Channel6]
 service_id	= 6
 id			= tv1
 name		= "TV 1"
 source1		= http://signal-server/stb/tv1.mpg
+lcn			= 25
+lcn_visible	= yes
 
 [Channel7]
 service_id	= 7
 id			= planetahit
 name		= "Planeta HIT"
 source1		= http://signal-server/stb/planetahit.mpg
+lcn			= 33
+lcn_visible	= no
 
 [Channel8]
 service_id	= 8
@@ -57,6 +71,8 @@ id			= fresh
 name		= "Radio Fresh"
 radio		= yes
 source		= http://signal-server/stb/fresh.mpg
+lcn			= 201
+lcn_visible	= yes
 
 [Channel9]
 service_id	= 9
@@ -64,3 +80,5 @@ id			= bgradio
 name		= "BG Radio"
 radio		= yes
 source1		= http://signal-server/stb/bgradio.mpg
+lcn			= 202
+lcn_visible	= yes


### PR DESCRIPTION
This patch is a rewrite of the work done by @gmakedonski and Georgi Chorbadzhiyski committed on Feb 2, 2015. Check the original work at https://github.com/lars18th/mptsd/commit/e38fb3bd29ad2d190ff16ec86e5375d5bf064053

The new implementation adds a new command line option to enable the LCN support. By default it's disabled. And when enabled a different code is executed to generate the NIT table. The original code is adapted and fixed.