### PR TITLE
add corrupted_packets_mode option

### DIFF
--- a/config.c
+++ b/config.c
@@ -134,6 +134,7 @@ int config_load_channels(CONFIG *conf) {
 		}
 
 		int eit_mode = ini_get_int(ini, 0, "Channel%d:eit_mode", i);
+		int corrupted_packets_mode = ini_get_int(ini, 0, "Channel%d:corrupted_packets_mode", i);
 
 		for (j=1;j<8;j++) {
 			char *source = ini_get_string(ini, NULL, "Channel%d:source%d", i, j);
@@ -147,7 +148,7 @@ int config_load_channels(CONFIG *conf) {
 				}
 				// Init channel
 				if (channel == NULL) {
-					channel = channel_new(service_id, is_radio, id, name, eit_mode, source, i, lcn, is_lcn_visible);
+					channel = channel_new(service_id, is_radio, id, name, eit_mode, corrupted_packets_mode, source, i, lcn, is_lcn_visible);
 				} else {
 					chansrc_add(channel, source);
 				}
@@ -227,7 +228,7 @@ int config_load_channels(CONFIG *conf) {
 		if (r->cookie != cookie) {
 			proxy_log(r, "Remove");
 			/* Replace channel reference with real object and instruct free_restreamer to free it */
-			r->channel = channel_new(r->channel->service_id, r->channel->radio, r->channel->id, r->channel->name, r->channel->eit_mode, r->channel->source, r->channel->index, r->channel->lcn, r->channel->lcn_visible);
+			r->channel = channel_new(r->channel->service_id, r->channel->radio, r->channel->id, r->channel->name, r->channel->eit_mode, r->channel->corrupted_packets_mode, r->channel->source, r->channel->index, r->channel->lcn, r->channel->lcn_visible);
 			r->freechannel = 1;
 			r->dienow = 1;
 		}

--- a/data.c
+++ b/data.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdarg.h>
 
 #include "libfuncs/io.h"
 #include "libfuncs/log.h"
@@ -121,7 +122,7 @@ void chansrc_set(CHANNEL *c, uint8_t src_id) {
 
 
 
-CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible){
+CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, int eit_mode, int corrupted_packets_mode, const char *source, int channel_index, int lcn, int is_lcn_visible){
 
     if (channel_index<=0 || channel_index>=256)
     {
@@ -142,6 +143,7 @@ CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *n
 	c->id = strdup(id);
 	c->name = strdup(name);
 	c->eit_mode = eit_mode;
+	c->corrupted_packets_mode = corrupted_packets_mode;
 	chansrc_add(c, source);
 
 
@@ -432,6 +434,17 @@ void nit_free(NIT **pn) {
 void proxy_log(INPUT *r, char *msg) {
 	if (!config->quiet)
 		LOGf("INPUT : [%-12s] %s fd: %d src: %s\n", r->channel->id, msg, r->sock, r->channel->source);
+}
+
+void proxy_logf(INPUT *r, const char *fmt, ...) {
+	char msg[1024];
+	va_list args;
+	va_start(args, fmt);
+	vsnprintf(msg, sizeof(msg) - 1, fmt, args);
+	va_end(args);
+	msg[sizeof(msg) - 1] = '\0';
+
+	proxy_log(r, msg);
 }
 
 void proxy_close(LIST *inputs, INPUT **input) {

--- a/data.h
+++ b/data.h
@@ -35,6 +35,11 @@
 
 #include "pidref.h"
 
+typedef struct {
+	uint64_t count;
+	uint64_t events;
+} CORRUPTION_STATS;
+
 typedef enum { udp_sock, tcp_sock } channel_source;
 
 typedef struct {
@@ -66,6 +71,10 @@ typedef struct {
 	int			radio;
 	int			lcn;
 	int			lcn_visible;
+	int 		corrupted_packets_mode; /* 	0 = don't check Transport error indicator (default)
+											1 = process corrupted TS packets normally
+											2 = drop corrupted TS packets
+					  					*/
 	char *		id;
 	char *		name;
 	int			eit_mode; /* 0 = ignore EIT data from input
@@ -133,6 +142,8 @@ typedef struct {
 	    freechannel:1;		/* Free channel data on object free (this is used in chanconf) */
 	int cookie;				/* Used in chanconf to determine if the restreamer is alrady checked */
 	int ifd;
+
+	CORRUPTION_STATS corruption_stats;
 
 	pthread_t thread;
 
@@ -231,7 +242,7 @@ EPG_ENTRY *	epg_new			(time_t start, int duration, char *encoding, char *event, 
 void		epg_free		(EPG_ENTRY **e);
 int			epg_changed		(EPG_ENTRY *a, EPG_ENTRY *b);
 
-CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible);
+CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, int eit_mode, int corrupted_packets_mode, const char *source, int channel_index, int lcn, int is_lcn_visible);
 void		channel_free	(CHANNEL **c);
 void		channel_free_epg(CHANNEL *c);
 
@@ -259,6 +270,7 @@ NIT *		nit_new			(uint16_t ts_id, char *freq, char *modulation, char *symbol_rat
 void		nit_free		(NIT **nit);
 
 void		proxy_log		(INPUT *r, char *msg);
+void		proxy_logf		(INPUT *r, const char *fmt, ...);
 void		proxy_close		(LIST *inputs, INPUT **input);
 
 #endif

--- a/mptsd_channels.conf
+++ b/mptsd_channels.conf
@@ -8,6 +8,9 @@ id			= btv
 name		= bTV
 eit_mode	= 0 # 0 = ignore EIT data from input
 				# 1 = forward EIT data for the configured service, ignore any other EIT data
+corrupted_packets_mode = 0	# 0 = don't check Transport error indicator (default)
+							# 1 = process corrupted TS packets normally
+							# 2 = drop corrupted TS packets
 source1		= http://signal-server/stb/btv.mpg
 #source2		= http://signal-server2/stb/btv.mpg
 #source3		= http://signal-server3/stb/btv.mpg


### PR DESCRIPTION
Adds the corrupted_packets_mode option to check the transport error indicator (TEI) flag on input streams