### PR TITLE
define Service Type of Service

### DIFF
--- a/config.c
+++ b/config.c
@@ -117,7 +117,11 @@ int config_load_channels(CONFIG *conf) {
 		if (!service_id)
 			continue;
 
+        // keep for backware compatibility
 		int is_radio = ini_get_bool(ini, 0, "Channel%d:radio", i);
+
+        int service_type = ini_get_int(ini, is_radio ? 2 : 1, "Channel%d:service_type", i);
+
 		int lcn = ini_get_int(ini, 0, "Channel%d:lcn", i);
 		int is_lcn_visible = ini_get_bool(ini, 0, "Channel%d:lcn_visible", i);
 
@@ -147,7 +151,7 @@ int config_load_channels(CONFIG *conf) {
 				}
 				// Init channel
 				if (channel == NULL) {
-					channel = channel_new(service_id, is_radio, id, name, eit_mode, source, i, lcn, is_lcn_visible);
+                    channel = channel_new(service_id, service_type, id, name, eit_mode, source, i, lcn, is_lcn_visible);
 				} else {
 					chansrc_add(channel, source);
 				}
@@ -227,7 +231,7 @@ int config_load_channels(CONFIG *conf) {
 		if (r->cookie != cookie) {
 			proxy_log(r, "Remove");
 			/* Replace channel reference with real object and instruct free_restreamer to free it */
-			r->channel = channel_new(r->channel->service_id, r->channel->radio, r->channel->id, r->channel->name, r->channel->eit_mode, r->channel->source, r->channel->index, r->channel->lcn, r->channel->lcn_visible);
+            r->channel = channel_new(r->channel->service_id, r->channel->service_type, r->channel->id, r->channel->name, r->channel->eit_mode, r->channel->source, r->channel->index, r->channel->lcn, r->channel->lcn_visible);
 			r->freechannel = 1;
 			r->dienow = 1;
 		}

--- a/data.c
+++ b/data.c
@@ -121,19 +121,18 @@ void chansrc_set(CHANNEL *c, uint8_t src_id) {
 
 
 
-CHANNEL *channel_new(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible){
+CHANNEL *channel_new(int service_id, int service_type, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible){
 
     if (channel_index<=0 || channel_index>=256)
     {
-        
 	    LOGf("CONFIG: Error channel_new invalid index %d\n", channel_index);
         return NULL;
     }
     //LOGf("CONFIG: ------------------channel_new() serviceid %d id %s name %s source %s index %d\n", service_id, id, name , source , channel_index);
-    
+
 	CHANNEL *c = calloc(1, sizeof(CHANNEL));
 	c->service_id = service_id;
-	c->radio = is_radio;
+	c->service_type = service_type;
 	c->index = channel_index;
 	c->lcn = lcn;
 	c->lcn_visible = is_lcn_visible;

--- a/data.h
+++ b/data.h
@@ -63,7 +63,7 @@ typedef struct {
 	int			base_pid;
 	int			service_id;
 	int			pmt_pid;
-	int			radio;
+	int			service_type;
 	int			lcn;
 	int			lcn_visible;
 	char *		id;
@@ -231,7 +231,7 @@ EPG_ENTRY *	epg_new			(time_t start, int duration, char *encoding, char *event, 
 void		epg_free		(EPG_ENTRY **e);
 int			epg_changed		(EPG_ENTRY *a, EPG_ENTRY *b);
 
-CHANNEL *	channel_new		(int service_id, int is_radio, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible);
+CHANNEL *	channel_new		(int service_id, int service_type, const char *id, const char *name, int eit_mode, const char *source, int channel_index, int lcn, int is_lcn_visible);
 void		channel_free	(CHANNEL **c);
 void		channel_free_epg(CHANNEL *c);
 

--- a/mptsd_channels.conf
+++ b/mptsd_channels.conf
@@ -16,6 +16,8 @@ source1		= http://signal-server/stb/btv.mpg
 #worktime	= 14:18-14:19
 lcn			= 2
 lcn_visible	= yes
+radio          = yes  # is this a radio service?
+service_type    = 31  # overrides optional parameter "radio" and specifies service type
 
 [Channel2]
 service_id	= 2

--- a/output_psi.c
+++ b/output_psi.c
@@ -74,7 +74,7 @@ static void output_psi_init_nit(CONFIG *conf, OUTPUT *o) {
 				uint32_t srv = 0;
 				srv  = (c->service_id &~ 0x00ff) << 8;
 				srv |= (c->service_id &~ 0xff00) << 8;
-				srv |= c->radio ? 0x02 : 0x01;
+                srv |= (c->service_type &~ 0xff);
 				services[num++] = srv;
 			}
 			list_unlock(conf->channels);
@@ -133,7 +133,7 @@ static void output_psi_init_nit(CONFIG *conf, OUTPUT *o) {
 				uint32_t srv = 0;
 				srv  = (c->service_id &~ 0x00ff) << 8;
 				srv |= (c->service_id &~ 0xff00) << 8;
-				srv |= c->radio ? 0x02 : 0x01;
+                srv |= (c->service_type &~ 0xff);
 				svc_services[num++] = srv;
 		}
 		list_unlock(conf->channels);
@@ -167,7 +167,7 @@ static void output_psi_init_sdt(CONFIG *conf, OUTPUT *o) {
 	list_lock(conf->channels);
 	list_for_each(conf->channels, lc, lctmp) {
 		CHANNEL *c = lc->data;
-		ts_sdt_add_service_descriptor(sdt, c->service_id, c->radio == 0, conf->provider_name, c->name);
+		ts_sdt_add_service_descriptor(sdt, c->service_id, c->service_type, conf->provider_name, c->name);
 	}
 	list_unlock(conf->channels);
 	gettimeofday(&o->sdt_ts, NULL);


### PR DESCRIPTION
only Service Type 1 for Video and 2 for Radio is obsolete since years

actually transmitted Service Types:

1 Video mpeg2 SD
2 Radio mp2
10 Radio aac
25 Video h264 HD
31 Video h265 UHD
and many more

It is better to let define service_type, similar to other arguments.

needs:
[https://github.com/gfto/libtsfuncs/pull/14](https://github.com/gfto/libtsfuncs/pull/14)
